### PR TITLE
Make harview uploadable to pypi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+dist
+*.py[co]
+*.egg-info

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[wheel]
+universal = 1

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,38 @@
+# !/usr/bin/env python
+
+from distutils.core import setup
+
+try:
+    from setuptools import setup, find_packages  # noqa
+except ImportError:
+    from distutils.core import setup
+
+
+setup(
+    name='harview',
+    version='0.2.0',
+    description=(
+        'A commandline tool which takes as input a .har (HTTP Archive) file '
+        'and dumps a human-readable summary of it to the console'
+    ),
+    long_description='',
+    license='GPLv3',
+    author='Ferry Boender',
+    url='https://github.com/fboender/harview',
+    scripts=[
+        'src/harview',
+    ],
+    classifiers=[
+        'Environment :: Console',
+        'Intended Audience :: Developers',
+        'Natural Language :: English',
+        'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: Implementation :: CPython',
+    ],
+)

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ except ImportError:
 
 setup(
     name='harview',
-    version='0.2.0',
+    version='0.2.1',
     description=(
         'A commandline tool which takes as input a .har (HTTP Archive) file '
         'and dumps a human-readable summary of it to the console'

--- a/src/harview
+++ b/src/harview
@@ -1,10 +1,12 @@
 #!/usr/bin/python
 
+
 import sys
 import json
 import argparse
 import urlparse
 import os
+
 
 def get_terminal_size():
     import os
@@ -30,11 +32,13 @@ def get_terminal_size():
 
     return int(cr[1]), int(cr[0])
 
+
 def color(color):
     if color:
         sys.stdout.write('\033[%sm' % (30 + color));
     else:
         sys.stdout.write('\033[0m')
+
 
 def text_wrap(s, cols=72, ident=4, ident_first=True):
     """
@@ -61,6 +65,7 @@ def text_wrap(s, cols=72, ident=4, ident_first=True):
             new_s += c
         pos += 1
     return(new_s)
+
 
 if __name__ == "__main__":
     global options

--- a/src/harview
+++ b/src/harview
@@ -4,8 +4,13 @@
 import sys
 import json
 import argparse
-import urlparse
 import os
+
+
+try:
+    from urlparse import urlparse
+except ImportError:
+    from urllib.parse import urlparse
 
 
 def get_terminal_size():
@@ -88,17 +93,17 @@ if __name__ == "__main__":
     cols, lines = get_terminal_size()
 
     try:
-        har = json.load(file(args.har_file, 'r'))
+        har = json.load(open(args.har_file, 'r'))
     except IndexError:
         sys.stderr.write("Usage: %s <file.har>\n" % (sys.argv[0]))
         sys.exit(1)
-    except ValueError, e:
+    except ValueError as e:
         sys.stderr.write("Invalid .har file: %s\n" % (str(e)))
         sys.exit(2)
 
     for entry in har['log']['entries']:
         # Filter out any requests we don't want to see
-        url = urlparse.urlparse(entry['request']['url'])
+        url = urlparse(entry['request']['url'])
         fname, ext = os.path.splitext(url.path)
         if ext in url_filter:
             continue


### PR DESCRIPTION
This should allow you to run

```
python setup.py sdist upload
```

which will upload it to pypi. This will then installable by anyone using `pip install harview`

I currently own the harview pypi name https://pypi.python.org/pypi/harview/0.1, but I only uploaded it to save it from being taken. I will delete this as soon as you are ready to upload it.

This PR also makes it Python3 compatible 
  